### PR TITLE
Replace grain hash with a bit-mixing one to fix repeating pattern

### DIFF
--- a/app/src/main/assets/shaders/atmosphere/atmosphere.frag
+++ b/app/src/main/assets/shaders/atmosphere/atmosphere.frag
@@ -1,5 +1,7 @@
 #version 300 es
 precision highp float;
+// hashU needs 32-bit ints; ES 3.00 defaults to mediump (only 16 bits guaranteed).
+precision highp int;
 
 in vec2 vTexCoord;
 out vec4 fragColor;
@@ -34,8 +36,19 @@ vec3 adjustColor(vec3 color) {
     return clamp(color, 0.0, 1.0);
 }
 
+// Bit-mixing hash, replacing fract(sin(dot(...))) -- that idiom collapses to a repeating pattern
+// at the coordinate magnitudes this grain grid produces (see #85).
+// uint overflow is defined wrapping in GLSL ES.
+uint hashU(uvec2 p) {
+    uint h = p.x * 73856093u ^ p.y * 19349663u;
+    h ^= h >> 13;
+    h *= 0x85ebca6bu;
+    h ^= h >> 16;
+    return h;
+}
+
 float random(vec2 co) {
-    return fract(sin(dot(co.xy, vec2(12.9898, 78.233))) * 43758.5453);
+    return float(hashU(uvec2(co)) & 0xFFFFFFu) / float(0x1000000u);
 }
 
 void main() {

--- a/app/src/main/assets/shaders/frostedBlur/frosted.frag
+++ b/app/src/main/assets/shaders/frostedBlur/frosted.frag
@@ -1,5 +1,7 @@
 #version 300 es
 precision highp float;
+// hashU needs 32-bit ints; ES 3.00 defaults to mediump (only 16 bits guaranteed).
+precision highp int;
 
 in vec2 vTexCoord;
 out vec4 fragColor;
@@ -18,8 +20,19 @@ uniform float uNoiseStrength;
 // App-drawer / recents blur, driven by wallpaper visibility. 0 = in view, 1 = hidden.
 uniform float uDrawerBlur;
 
+// Bit-mixing hash, replacing fract(sin(dot(...))) -- that idiom collapses to a repeating pattern
+// at the coordinate magnitudes this grain grid produces (see #85).
+// uint overflow is defined wrapping in GLSL ES.
+uint hashU(uvec2 p) {
+    uint h = p.x * 73856093u ^ p.y * 19349663u;
+    h ^= h >> 13;
+    h *= 0x85ebca6bu;
+    h ^= h >> 16;
+    return h;
+}
+
 float random(vec2 co) {
-    return fract(sin(dot(co.xy, vec2(12.9898, 78.233))) * 43758.5453);
+    return float(hashU(uvec2(co)) & 0xFFFFFFu) / float(0x1000000u);
 }
 
 void main() {

--- a/app/src/main/assets/shaders/reverseAtmosphere/atmosphere_blur_to_sharp.frag
+++ b/app/src/main/assets/shaders/reverseAtmosphere/atmosphere_blur_to_sharp.frag
@@ -1,5 +1,7 @@
 #version 300 es
 precision highp float;
+// hashU needs 32-bit ints; ES 3.00 defaults to mediump (only 16 bits guaranteed).
+precision highp int;
 
 in vec2 vTexCoord;
 out vec4 fragColor;
@@ -37,8 +39,19 @@ vec3 adjustColor(vec3 color) {
     return clamp(color, 0.0, 1.0);
 }
 
+// Bit-mixing hash, replacing fract(sin(dot(...))) -- that idiom collapses to a repeating pattern
+// at the coordinate magnitudes this grain grid produces (see #85).
+// uint overflow is defined wrapping in GLSL ES.
+uint hashU(uvec2 p) {
+    uint h = p.x * 73856093u ^ p.y * 19349663u;
+    h ^= h >> 13;
+    h *= 0x85ebca6bu;
+    h ^= h >> 16;
+    return h;
+}
+
 float random(vec2 co) {
-    return fract(sin(dot(co.xy, vec2(12.9898, 78.233))) * 43758.5453);
+    return float(hashU(uvec2(co)) & 0xFFFFFFu) / float(0x1000000u);
 }
 
 void main() {


### PR DESCRIPTION
Fixes #85

The grain hash returns only 1.7% distinct values at the coordinate magnitudes it runs at, with neighbouring cells strongly correlated so the "noise" is a fixed repeating pattern. Details and before/after images are in #85.

This replaces it with a bit-mixing hash in the three shaders that share the grain block. Integer mixing is cheaper than `sin`, so it costs nothing.

**Nothing else changes** grain cell geometry, `uNoiseScale` and the saved `noise_scale` preference all behave exactly as before. The diff is one line replaced per shader, plus the hash function and a `precision highp int;` declaration (ES 3.00 defaults integers to mediump, which would silently wrap the 32-bit constants).

Verified on Nothing Phone (1) (1080x2400)